### PR TITLE
Increase the inspection depth for metadata

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -94,7 +94,7 @@ Mail.prototype.log = function (level, msg, meta, callback) {
       delete meta.stack;
     }
 
-    body += "\n\n" + util.inspect(meta, {depth: 5}); // add some pretty printing
+    body += "\n\n" + util.inspect(meta, {depth: 20}); // add some pretty printing
     body += "\nStack Trace:\n\n";
     body += stack;
   }


### PR DESCRIPTION
This PR fixes an issue where the error metadata is logged as `metadata: { errors: [ [Object] ] } }`, making it useless. Note that the current version of `winston-mail` has the option to use a custom formatter so an alternate strategy to fix this is to update our vendored version then move the formatter to backend.